### PR TITLE
fix: handle IndexedDB unavailable error on GH Pages

### DIFF
--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -241,8 +241,11 @@ async function apiOr<T extends () => Promise<any>>(
   local: T,
 ): Promise<Awaited<ReturnType<T>>> {
   try {
-    await isLoggedIn();
-    return await api();
+    const loggedIn = await isLoggedIn();
+    if (loggedIn) {
+      return await api();
+    }
+    return await local();
   } catch (error) {
     return await local();
   }

--- a/src/lib/event-store.ts
+++ b/src/lib/event-store.ts
@@ -376,9 +376,14 @@ function generateId() {
 }
 
 async function readState(): Promise<State> {
-  const persisted = await readPersistedCollections();
-  if (persisted) {
-    return persisted;
+  try {
+    const persisted = await readPersistedCollections();
+    if (persisted) {
+      return persisted;
+    }
+  } catch {
+    // IndexedDB may be unavailable (private browsing, restricted storage, etc.)
+    // Fall through to return empty state
   }
 
   return {


### PR DESCRIPTION
- Wrap readState() in try/catch to gracefully handle IndexedDB being unavailable (private browsing, restricted storage)
- Fix apiOr() to check isLoggedIn() return value before calling API, avoiding unnecessary fallback chain when not authenticated